### PR TITLE
f.close() —> report_filename.close()

### DIFF
--- a/pmlb/write_metadata.py
+++ b/pmlb/write_metadata.py
@@ -171,7 +171,7 @@ def generate_pmlb_summary(local_cache_dir=None):
             #writer.writerow([file,str(len(df.axes[0])),str(len(df.axes[1])-1),feat[0],feat[1],feat[2],endpoint,mse[0],mse[1],mse[2]])
             writer.writerow([dataset,str(len(df.axes[0])),str(len(df.axes[1])-1),feat[0],feat[1],feat[2],endpoint,int(mse[0]),mse[1]])
     finally:
-        f.close()
+        report_filename.close()
 
 if __name__ =='__main__':
     local_dir = '../'
@@ -179,5 +179,3 @@ if __name__ =='__main__':
     for d in dataset_names:
         print(d,'...')
         generate_description(d,local_cache_dir=local_dir)
-
-


### PR DESCRIPTION
flake8 testing of https://github.com/EpistasisLab/penn-ml-benchmarks on Python 2.7.14

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./pmlb/write_metadata.py:174:9: F821 undefined name 'f'
        f.close()
        ^
```