### PR TITLE
Add metadata to bupa, read description!

### DIFF
--- a/datasets/bupa/metadata.yaml
+++ b/datasets/bupa/metadata.yaml
@@ -1,26 +1,40 @@
 #Generated automatically by pmlb/write_metadata.py
+#Reviewed by Daniel Goldberg
+
+TODO!
+Description of current target: >
+  Train/test selector.
+  The classification of either 1 or 2 was used by BUPA researchers to decide what data should go in train vs in test.
+  This feature is NOT whether the individual had a liver condition.
+  The dataset does not contain ANY features determining presence or absence of a liver condition.
+  The Drinks feature is designed to be the dependent variable of this dataset.
+Remove TODO, this line, and everything in between, when dataset has been changed.
+  
 dataset: bupa
-description: None yet. See our contributing guide to help us add one.
-source: None yet. See our contributing guide to help us add one.
-publication: None yet. See our contributing guide to help us add one.
-task: classification
+description: >
+  BUPA medical research on liver disease that might arise from excessive alcohol consumption.
+  The first five features are different blood tests that may be sensitive to liver disorders.
+  Each row is a record of a single male individual.
+source: https://www.openml.org/d/8
+publication: https://archive.ics.uci.edu/ml/datasets/Liver+Disorders
+task: regression
 target:
-  type: binary
-  description: None yet. See our contributing guide to help us add one.
-  code: None yet. See our contributing guide to help us add one.
+  type: continuous
+  description: >
+    Number of half-pint equivalents of alcoholic beverages drunk per day.
 features: # list of features in the dataset
   - name: Mcv
     type: continuous
-    description: null # optional but recommended, what the feature measures/indicates, unit
-    code: null # optional, coding information, e.g., Control = 0, Case = 1
-    transform: ~ # optional, any transformation performed on the feature, e.g., log scaled
+    description: mean corpuscular volume
   - name: Alkphos
     type: continuous
+    description: alkaline phosphotase
   - name: Sgpt
     type: continuous
+    description: alanine aminotransferase
   - name: Sgot
     type: continuous
+    description: aspartate aminotransferase
   - name: Gammagt
     type: continuous
-  - name: Drinks
-    type: continuous
+    description: gamma-glutamyl transpeptidase


### PR DESCRIPTION
Google collab notebook: https://colab.research.google.com/drive/1368j3Ug67AvZPVKMp7owVjA-JwNqL5V6#scrollTo=fXufmqGCh372

This dataset is confusing - the current target is a train/test selector. Most analysis done on this dataset (according to openML) uses the 6th feature, "Drinks", as the target. The PMLB dataset should be changed to reflect this. I changed the metadata.yaml file to reflect this change preemptively.
Changed yaml to treat 6th feature, currently "Drinks", as new target, with 7th feature removed - this needs to be changed.
I removed "Drinks" from features and made the "target" metadata fit that of "Drinks" so we don't need to edit the metadata again, beyond removing "TODO" and following description of previous target.

This publication regarding this dataset may be useful: https://www.richardsandesforsyth.net/pubs/JMRF_DiagnosingDisorder_PRL2016.pdf