### PR TITLE
Add metadata to chess

### DIFF
--- a/datasets/chess/metadata.yaml
+++ b/datasets/chess/metadata.yaml
@@ -19,8 +19,8 @@ target:
   type: binary
   description: Represents if white can win or white cannot win
   code: >
-    ''nowin'' = 0, 
-    ''won'' = 1, 
+    'nowin' = 0, 
+    'won' = 1, 
 features: # list of features in the dataset
   - name: A00
     type: binary
@@ -28,182 +28,182 @@ features: # list of features in the dataset
       See general description for this and all following features
       (Each feature correponds to a particular position)
     code: >
-      ''f'' = 0, 
-      ''t'' = 1, 
+      'f' = 0, 
+      't' = 1, 
   - name: A01
     type: binary
     code: >
-      ''f'' = 0, 
-      ''t'' = 1, 
+      'f' = 0, 
+      't' = 1, 
   - name: A02
     type: binary
     code: >
-      ''f'' = 0, 
-      ''t'' = 1, 
+      'f' = 0, 
+      't' = 1, 
   - name: A03
     type: binary
     code: >
-      ''f'' = 0, 
-      ''t'' = 1, 
+      'f' = 0, 
+      't' = 1, 
   - name: A04
     type: binary
     code: >
-      ''f'' = 0, 
-      ''t'' = 1, 
+      'f' = 0, 
+      't' = 1, 
   - name: A05
     type: binary
     code: >
-      ''f'' = 0, 
-      ''t'' = 1, 
+      'f' = 0, 
+      't' = 1, 
   - name: A06
     type: binary
     code: >
-      ''f'' = 0, 
-      ''t'' = 1, 
+      'f' = 0, 
+      't' = 1, 
   - name: A07
     type: binary
     code: >
-      ''f'' = 0, 
-      ''t'' = 1, 
+      'f' = 0, 
+      't' = 1, 
   - name: A08
     type: binary
     code: >
-      ''f'' = 0, 
-      ''t'' = 1, 
+      'f' = 0, 
+      't' = 1, 
   - name: A09
     type: binary
     code: >
-      ''f'' = 0, 
-      ''t'' = 1, 
+      'f' = 0, 
+      't' = 1, 
   - name: A10
     type: binary
     code: >
-      ''f'' = 0, 
-      ''t'' = 1, 
+      'f' = 0, 
+      't' = 1, 
   - name: A11
     type: binary
     code: >
-      ''f'' = 0, 
-      ''t'' = 1, 
+      'f' = 0, 
+      't' = 1, 
   - name: A12
     type: binary
     code: >
-      ''f'' = 0, 
-      ''t'' = 1, 
+      'f' = 0, 
+      't' = 1, 
   - name: A13
     type: binary
     code: >
-      ''f'' = 0, 
-      ''t'' = 1, 
+      'f' = 0, 
+      't' = 1, 
   - name: A14
     type: discrete
     code: >
-      ''b'' = 0, 
-      ''n'' = 1, 
-      ''w'' = 2,
+      'b' = 0, 
+      'n' = 1, 
+      'w' = 2,
   - name: A15
     type: binary
     code: >
-      ''f'' = 0, 
-      ''t'' = 1, 
+      'f' = 0, 
+      't' = 1, 
   - name: A16
     type: binary
     code: >
-      ''f'' = 0, 
-      ''t'' = 1, 
+      'f' = 0, 
+      't' = 1, 
   - name: A17
     type: binary
     code: >
-      ''f'' = 0, 
-      ''t'' = 1, 
+      'f' = 0, 
+      't' = 1, 
   - name: A18
     type: binary
     code: >
-      ''f'' = 0, 
-      ''t'' = 1, 
+      'f' = 0, 
+      't' = 1, 
   - name: A19
     type: binary
     code: >
-      ''f'' = 0, 
-      ''t'' = 1, 
+      'f' = 0, 
+      't' = 1, 
   - name: A20
     type: binary
     code: >
-      ''f'' = 0, 
-      ''t'' = 1, 
+      'f' = 0, 
+      't' = 1, 
   - name: A21
     type: binary
     code: >
-      ''f'' = 0, 
-      ''t'' = 1, 
+      'f' = 0, 
+      't' = 1, 
   - name: A22
     type: binary
     code: >
-      ''f'' = 0, 
-      ''t'' = 1, 
+      'f' = 0, 
+      't' = 1, 
   - name: A23
     type: binary
     code: >
-      ''f'' = 0, 
-      ''t'' = 1, 
+      'f' = 0, 
+      't' = 1, 
   - name: A24
     type: binary
     code: >
-      ''f'' = 0, 
-      ''t'' = 1, 
+      'f' = 0, 
+      't' = 1,  
   - name: A25
     type: binary
     code: >
-      ''f'' = 0, 
-      ''t'' = 1, 
+      'f' = 0, 
+      't' = 1, 
   - name: A26
     type: binary
     code: >
-      ''f'' = 0, 
-      ''t'' = 1, 
+      'f' = 0, 
+      't' = 1, 
   - name: A27
     type: binary
     code: >
-      ''f'' = 0, 
-      ''t'' = 1, 
+      'f' = 0, 
+      't' = 1, 
   - name: A28
     type: binary
     code: >
-      ''f'' = 0, 
-      ''t'' = 1, 
+      'f' = 0, 
+      't' = 1, 
   - name: A29
     type: binary
     code: >
-      ''f'' = 0, 
-      ''t'' = 1, 
+      'f' = 0, 
+      't' = 1, 
   - name: A30
     type: binary
     code: >
-      ''f'' = 0, 
-      ''t'' = 1, 
+      'f' = 0, 
+      't' = 1, 
   - name: A31
     type: binary
     code: >
-      ''f'' = 0, 
-      ''t'' = 1, 
+      'f' = 0, 
+      't' = 1, 
   - name: A32
     type: binary
     code: >
-      ''f'' = 0, 
-      ''t'' = 1, 
+      'f' = 0, 
+      't' = 1, 
   - name: A33
     type: binary
     code: >
-      ''f'' = 0, 
-      ''t'' = 1, 
+      'f' = 0, 
+      't' = 1, 
   - name: A34
     type: binary
     code: >
-      ''f'' = 0, 
-      ''t'' = 1, 
+      'f' = 0, 
+      't' = 1, 
   - name: A35
     type: binary
     code: >
-      ''b'' = 0, 
-      ''n'' = 1, 
-      ''w'' = 2,
+      'b' = 0, 
+      'n' = 1, 
+      'w' = 2,

--- a/datasets/chess/metadata.yaml
+++ b/datasets/chess/metadata.yaml
@@ -38,7 +38,7 @@ features: # list of features in the dataset
   - name: A02
     type: binary
     code: >
-      'f' = 0, 
+      'f' = 0,
       't' = 1
   - name: A03
     type: binary
@@ -53,13 +53,13 @@ features: # list of features in the dataset
   - name: A05
     type: binary
     code: >
-      'f' = 0, 
+      'f' = 0,
       't' = 1
   - name: A06
     type: binary
     code: >
       'f' = 0,
-      't' = 1, 
+      't' = 1
   - name: A07
     type: binary
     code: >
@@ -119,8 +119,8 @@ features: # list of features in the dataset
   - name: A18
     type: binary
     code: >
-      'f' = 0, 
-      't' = 1, 
+      'f' = 0,
+      't' = 1
   - name: A19
     type: binary
     code: >
@@ -145,7 +145,7 @@ features: # list of features in the dataset
     type: binary
     code: >
       'f' = 0, 
-      't' = 1, 
+      't' = 1
   - name: A24
     type: binary
     code: >
@@ -160,7 +160,7 @@ features: # list of features in the dataset
     type: binary
     code: >
       'f' = 0, 
-      't' = 1, 
+      't' = 1
   - name: A27
     type: binary
     code: >

--- a/datasets/chess/metadata.yaml
+++ b/datasets/chess/metadata.yaml
@@ -1,86 +1,209 @@
 #Generated automatically by pmlb/write_metadata.py
 dataset: chess
-description: None yet. See our contributing guide to help us add one.
-source: None yet. See our contributing guide to help us add one.
-publication: None yet. See our contributing guide to help us add one.
+description: >
+  Whether a chess game is winnable or not, giving the following conditions:
+    White side has king and rook;
+    Black side has king and pawn, with pawn one move away from queening (on the second to last row);
+    It is white's turn to move.
+  The format of the data is as follows:
+    Each instance has 36 features that describe the state of the board and a 37th feature (target) that classifies if
+    a win is possible.
+  Each feature correponds to a particular position.
+source: https://www.openml.org/d/3
+publication: >
+  Database originally generated and described by Alen Shapiro
+  Donor/Coder: Rob Holte
+  Database was supplied to Holte by Peter Clark of the Turing Institute in Glasgow, 1 August 1989
 task: classification
 target:
   type: binary
-  description: None yet. See our contributing guide to help us add one.
-  code: None yet. See our contributing guide to help us add one.
+  description: Represents if white can win or white cannot win
+  code: >
+    ''nowin'' = 0, 
+    ''won'' = 1, 
 features: # list of features in the dataset
   - name: A00
-    type: categorical
-    description: null # optional but recommended, what the feature measures/indicates, unit
-    code: null # optional, coding information, e.g., Control = 0, Case = 1
-    transform: ~ # optional, any transformation performed on the feature, e.g., log scaled
+    type: binary
+    description: >
+      See general description for this and all following features
+      (Each feature correponds to a particular position)
+    code: >
+      ''f'' = 0, 
+      ''t'' = 1, 
   - name: A01
-    type: categorical
+    type: binary
+    code: >
+      ''f'' = 0, 
+      ''t'' = 1, 
   - name: A02
-    type: categorical
+    type: binary
+    code: >
+      ''f'' = 0, 
+      ''t'' = 1, 
   - name: A03
-    type: categorical
+    type: binary
+    code: >
+      ''f'' = 0, 
+      ''t'' = 1, 
   - name: A04
-    type: categorical
+    type: binary
+    code: >
+      ''f'' = 0, 
+      ''t'' = 1, 
   - name: A05
-    type: categorical
+    type: binary
+    code: >
+      ''f'' = 0, 
+      ''t'' = 1, 
   - name: A06
-    type: categorical
+    type: binary
+    code: >
+      ''f'' = 0, 
+      ''t'' = 1, 
   - name: A07
-    type: categorical
+    type: binary
+    code: >
+      ''f'' = 0, 
+      ''t'' = 1, 
   - name: A08
-    type: categorical
+    type: binary
+    code: >
+      ''f'' = 0, 
+      ''t'' = 1, 
   - name: A09
-    type: categorical
+    type: binary
+    code: >
+      ''f'' = 0, 
+      ''t'' = 1, 
   - name: A10
-    type: categorical
+    type: binary
+    code: >
+      ''f'' = 0, 
+      ''t'' = 1, 
   - name: A11
-    type: categorical
+    type: binary
+    code: >
+      ''f'' = 0, 
+      ''t'' = 1, 
   - name: A12
-    type: categorical
+    type: binary
+    code: >
+      ''f'' = 0, 
+      ''t'' = 1, 
   - name: A13
-    type: categorical
+    type: binary
+    code: >
+      ''f'' = 0, 
+      ''t'' = 1, 
   - name: A14
-    type: categorical
+    type: discrete
+    code: >
+      ''b'' = 0, 
+      ''n'' = 1, 
+      ''w'' = 2,
   - name: A15
-    type: categorical
+    type: binary
+    code: >
+      ''f'' = 0, 
+      ''t'' = 1, 
   - name: A16
-    type: categorical
+    type: binary
+    code: >
+      ''f'' = 0, 
+      ''t'' = 1, 
   - name: A17
-    type: categorical
+    type: binary
+    code: >
+      ''f'' = 0, 
+      ''t'' = 1, 
   - name: A18
-    type: categorical
+    type: binary
+    code: >
+      ''f'' = 0, 
+      ''t'' = 1, 
   - name: A19
-    type: categorical
+    type: binary
+    code: >
+      ''f'' = 0, 
+      ''t'' = 1, 
   - name: A20
-    type: categorical
+    type: binary
+    code: >
+      ''f'' = 0, 
+      ''t'' = 1, 
   - name: A21
-    type: categorical
+    type: binary
+    code: >
+      ''f'' = 0, 
+      ''t'' = 1, 
   - name: A22
-    type: categorical
+    type: binary
+    code: >
+      ''f'' = 0, 
+      ''t'' = 1, 
   - name: A23
-    type: categorical
+    type: binary
+    code: >
+      ''f'' = 0, 
+      ''t'' = 1, 
   - name: A24
-    type: categorical
+    type: binary
+    code: >
+      ''f'' = 0, 
+      ''t'' = 1, 
   - name: A25
-    type: categorical
+    type: binary
+    code: >
+      ''f'' = 0, 
+      ''t'' = 1, 
   - name: A26
-    type: categorical
+    type: binary
+    code: >
+      ''f'' = 0, 
+      ''t'' = 1, 
   - name: A27
-    type: categorical
+    type: binary
+    code: >
+      ''f'' = 0, 
+      ''t'' = 1, 
   - name: A28
-    type: categorical
+    type: binary
+    code: >
+      ''f'' = 0, 
+      ''t'' = 1, 
   - name: A29
-    type: categorical
+    type: binary
+    code: >
+      ''f'' = 0, 
+      ''t'' = 1, 
   - name: A30
-    type: categorical
+    type: binary
+    code: >
+      ''f'' = 0, 
+      ''t'' = 1, 
   - name: A31
-    type: categorical
+    type: binary
+    code: >
+      ''f'' = 0, 
+      ''t'' = 1, 
   - name: A32
-    type: categorical
+    type: binary
+    code: >
+      ''f'' = 0, 
+      ''t'' = 1, 
   - name: A33
-    type: categorical
+    type: binary
+    code: >
+      ''f'' = 0, 
+      ''t'' = 1, 
   - name: A34
-    type: categorical
+    type: binary
+    code: >
+      ''f'' = 0, 
+      ''t'' = 1, 
   - name: A35
-    type: categorical
+    type: binary
+    code: >
+      ''b'' = 0, 
+      ''n'' = 1, 
+      ''w'' = 2,

--- a/datasets/chess/metadata.yaml
+++ b/datasets/chess/metadata.yaml
@@ -19,8 +19,8 @@ target:
   type: binary
   description: Represents if white can win or white cannot win
   code: >
-    'nowin' = 0, 
-    'won' = 1, 
+    'nowin' = 0,
+    'won' = 1
 features: # list of features in the dataset
   - name: A00
     type: binary
@@ -28,94 +28,94 @@ features: # list of features in the dataset
       See general description for this and all following features
       (Each feature correponds to a particular position)
     code: >
-      'f' = 0, 
-      't' = 1, 
+      'f' = 0,
+      't' = 1
   - name: A01
     type: binary
     code: >
-      'f' = 0, 
-      't' = 1, 
+      'f' = 0,
+      't' = 1
   - name: A02
     type: binary
     code: >
       'f' = 0, 
-      't' = 1, 
+      't' = 1
   - name: A03
     type: binary
     code: >
-      'f' = 0, 
-      't' = 1, 
+      'f' = 0,
+      't' = 1
   - name: A04
     type: binary
     code: >
-      'f' = 0, 
-      't' = 1, 
+      'f' = 0,
+      't' = 1
   - name: A05
     type: binary
     code: >
       'f' = 0, 
-      't' = 1, 
+      't' = 1
   - name: A06
     type: binary
     code: >
-      'f' = 0, 
+      'f' = 0,
       't' = 1, 
   - name: A07
     type: binary
     code: >
       'f' = 0, 
-      't' = 1, 
+      't' = 1
   - name: A08
     type: binary
     code: >
       'f' = 0, 
-      't' = 1, 
+      't' = 1
   - name: A09
     type: binary
     code: >
       'f' = 0, 
-      't' = 1, 
+      't' = 1
   - name: A10
     type: binary
     code: >
       'f' = 0, 
-      't' = 1, 
+      't' = 1
   - name: A11
     type: binary
     code: >
       'f' = 0, 
-      't' = 1, 
+      't' = 1
   - name: A12
     type: binary
     code: >
-      'f' = 0, 
-      't' = 1, 
+      'f' = 0,
+      't' = 1
   - name: A13
     type: binary
     code: >
       'f' = 0, 
-      't' = 1, 
+      't' = 1
   - name: A14
     type: discrete
     code: >
-      'b' = 0, 
-      'n' = 1, 
-      'w' = 2,
+      'b' = 0,
+      'n' = 1,
+      'w' = 2
   - name: A15
     type: binary
     code: >
-      'f' = 0, 
-      't' = 1, 
+      'f' = 0,
+      't' = 1
   - name: A16
     type: binary
     code: >
-      'f' = 0, 
-      't' = 1, 
+      'f' = 0,
+      't' = 1
   - name: A17
     type: binary
     code: >
-      'f' = 0, 
-      't' = 1, 
+      'f' = 0,
+      't' = 1
   - name: A18
     type: binary
     code: >
@@ -124,23 +124,23 @@ features: # list of features in the dataset
   - name: A19
     type: binary
     code: >
-      'f' = 0, 
-      't' = 1, 
+      'f' = 0,
+      't' = 1
   - name: A20
     type: binary
     code: >
-      'f' = 0, 
-      't' = 1, 
+      'f' = 0,
+      't' = 1
   - name: A21
     type: binary
     code: >
       'f' = 0, 
-      't' = 1, 
+      't' = 1
   - name: A22
     type: binary
     code: >
-      'f' = 0, 
-      't' = 1, 
+      'f' = 0,
+      't' = 1
   - name: A23
     type: binary
     code: >
@@ -150,12 +150,12 @@ features: # list of features in the dataset
     type: binary
     code: >
       'f' = 0, 
-      't' = 1,  
+      't' = 1
   - name: A25
     type: binary
     code: >
-      'f' = 0, 
-      't' = 1, 
+      'f' = 0,
+      't' = 1
   - name: A26
     type: binary
     code: >
@@ -164,46 +164,46 @@ features: # list of features in the dataset
   - name: A27
     type: binary
     code: >
-      'f' = 0, 
-      't' = 1, 
+      'f' = 0,
+      't' = 1
   - name: A28
     type: binary
     code: >
-      'f' = 0, 
-      't' = 1, 
+      'f' = 0,
+      't' = 1
   - name: A29
     type: binary
     code: >
       'f' = 0, 
-      't' = 1, 
+      't' = 1
   - name: A30
     type: binary
     code: >
-      'f' = 0, 
-      't' = 1, 
+      'f' = 0,
+      't' = 1
   - name: A31
     type: binary
     code: >
-      'f' = 0, 
-      't' = 1, 
+      'f' = 0,
+      't' = 1
   - name: A32
     type: binary
     code: >
-      'f' = 0, 
-      't' = 1, 
+      'f' = 0,
+      't' = 1
   - name: A33
     type: binary
     code: >
-      'f' = 0, 
-      't' = 1, 
+      'f' = 0,
+      't' = 1
   - name: A34
     type: binary
     code: >
-      'f' = 0, 
-      't' = 1, 
+      'f' = 0,
+      't' = 1
   - name: A35
     type: binary
     code: >
-      'b' = 0, 
-      'n' = 1, 
-      'w' = 2,
+      'b' = 0,
+      'n' = 1,
+      'w' = 2


### PR DESCRIPTION
Google collab notebook: https://colab.research.google.com/drive/1e-69p4HbcP9IZhSRrwQaHAobvLJ7gHTn#scrollTo=Mb-0nCAewJgS

The only part I might change is the 'code' for most of the features. With the exceptions of A14 and A35, every feature has the same 'code'. There may be a better place to put this information to reduce redundancy. However, while I feel this change could streamline the document, I do not believe it is a necessary change.