### PR TITLE
Add a schema for `metadata.yaml` files

### DIFF
--- a/metadata.schema.json
+++ b/metadata.schema.json
@@ -1,0 +1,94 @@
+{
+  "$id": "https://github.com/EpistasisLab/penn-ml-benchmarks/metadata.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "PMLB dataset metadata",
+  "type": "object",
+  "required": [
+    "dataset",
+    "description",
+    "source",
+    "task",
+    "target",
+    "features"
+  ],
+  "properties": {
+    "dataset": {
+      "type": "string",
+      "description": "Dataset name (required)." 
+    },
+    "description": {
+      "type": "string",
+      "description": "Dataset description (required),"
+    },
+    "source": {
+      "type": "string",
+      "description": "URL link to the source from where the dataset was retrieved (required)."
+    },
+    "publication": {
+      "type": "string",
+      "description": "Study that generated the dataset (doi, pmid, pmcid, or url)."
+    },
+    "task": {
+      "type": "string",
+      "description": "\"classification\" or \"regression\" (required)."
+    },
+    "keywords": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Descriptive terms for the dataset, e.g., bioinformatics, images, economics, etc."
+    },
+    "target": { "$ref": "#/definitions/target" },
+    "features": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/feature" }
+    },
+  },
+  "definitions": {
+    "target": {
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "One of \"continuous\", \"nominal\", or \"ordinal\"."
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of the endpoint/outcome. Include units when appropriate."
+        },
+        "code": {
+          "type": "string",
+          "description": "Description of values and what they mean, e.g., 'Control = 0, Case = 1'."
+        }
+      }
+    },
+    "feature": {
+      "required": [
+        "name",
+        "type"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the feature (required)."
+        },
+        "type": {
+          "type": "string",
+          "description": "One of \"continuous\", \"nominal\", or \"ordinal\"."
+        },
+        "description": {
+          "type": "string",
+          "description": "What the feature measures or indicates. Include units when appropriate."
+        },
+        "code": {
+          "type": "string",
+          "description": "Description of values and what they mean, e.g., 'Control = 0, Case = 1'."
+        },
+        "transform": {
+          "type": "string",
+          "description": "Any transformations applied to the feature, e.g., 'log scaled'."
+        },
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes #108 

Future work includes adding a validator for `metadata.yaml` files that makes use of this schema definition.